### PR TITLE
Bump httpclient from 4.5.3 to 4.5.13 in /multithreaded-http-client

### DIFF
--- a/multithreaded-http-client/pom.xml
+++ b/multithreaded-http-client/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.3</version>
+      <version>4.5.13</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Bumps httpclient from 4.5.3 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>